### PR TITLE
feat: add persistent chat store

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,13 +29,15 @@ const nextConfig = {
         exposes: {
           './Error': './src/pages/_error.tsx',
           './Providers': './src/providers/providers.tsx',
+          './chat-store': './src/store/chat-store.ts',
         },
         shared: {
           'react-dom': { singleton: true, requiredVersion: false },
           'next-intl': { singleton: true, requiredVersion: false },
+          'chat-store': { singleton: true, eager: true },
           // '@gabrielmbatista/ui-library-stencil': {
           //   singleton: true,
-          //   eager: true, 
+          //   eager: true,
           //   requiredVersion: false,
           // },
           // 'next-auth': { singleton: true },

--- a/src/providers/ChatStoreProvider.tsx
+++ b/src/providers/ChatStoreProvider.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useChatStore, chatStoreActions } from 'chat-store';
+
+function getCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+function setCookie(name: string, value: string): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${60 * 60 * 24 * 30}`;
+}
+
+function deleteCookie(name: string): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${name}=; path=/; max-age=0`;
+}
+
+export function ChatStoreProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { hydrate } = chatStoreActions;
+  const conversationId = useChatStore((s) => s.conversationId);
+
+  useEffect(() => {
+    const cid = (router.query.cid as string) || getCookie('cid');
+    if (cid) {
+      hydrate(cid);
+    }
+  }, [router.query, hydrate]);
+
+  useEffect(() => {
+    if (conversationId) {
+      setCookie('cid', conversationId);
+    } else {
+      deleteCookie('cid');
+    }
+  }, [conversationId]);
+
+  return <>{children}</>;
+}
+

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -5,12 +5,15 @@ import { I18nProvider } from './I18nProvider';
 import { SessionProvider } from 'next-auth/react';
 import { Session } from 'next-auth';
 import { ResolutionProvider } from './ResolutionProvider';
+import { ChatStoreProvider } from './ChatStoreProvider';
 
 export function Providers({ children, session }: { children: ReactNode; session: Session | null }) {
   return (
     <I18nProvider>
       <ResolutionProvider>
-        <SessionProvider session={session}>{children}</SessionProvider>
+        <SessionProvider session={session}>
+          <ChatStoreProvider>{children}</ChatStoreProvider>
+        </SessionProvider>
       </ResolutionProvider>
     </I18nProvider>
   );

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -1,0 +1,131 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+export type ChatMessage = {
+  id: string;
+  role: string;
+  text: string;
+  ts: number;
+};
+
+export type ChatStatus = 'idle' | 'sending' | 'error';
+
+interface ChatState {
+  conversationId?: string;
+  messages: ChatMessage[];
+  status: ChatStatus;
+  conversations: Record<string, { messages: ChatMessage[]; status: ChatStatus }>;
+}
+
+const initialState: ChatState = {
+  conversationId: undefined,
+  messages: [],
+  status: 'idle',
+  conversations: {},
+};
+
+let state: ChatState = initialState;
+const listeners = new Set<() => void>();
+
+function setState(partial: Partial<ChatState> | ((s: ChatState) => Partial<ChatState>)) {
+  const next = typeof partial === 'function' ? partial(state) : partial;
+  state = { ...state, ...next };
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chat-store', JSON.stringify({ conversations: state.conversations }));
+  }
+  listeners.forEach((l) => l());
+}
+
+export function useChatStore<T>(selector: (s: ChatState) => T): T {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    () => selector(state),
+    () => selector(state),
+  );
+}
+
+export const chatStoreActions = {
+  start(id: string) {
+    setState((s) => ({
+      conversationId: id,
+      messages: [],
+      status: 'idle',
+      conversations: { ...s.conversations, [id]: { messages: [], status: 'idle' } },
+    }));
+  },
+  append(message: ChatMessage) {
+    setState((s) => {
+      const id = s.conversationId;
+      if (!id) return {};
+      const messages = [...s.messages, message];
+      return {
+        messages,
+        conversations: { ...s.conversations, [id]: { messages, status: s.status } },
+      };
+    });
+  },
+  hydrate(id: string) {
+    if (typeof window !== 'undefined') {
+      try {
+        const raw = localStorage.getItem('chat-store');
+        if (raw) {
+          const data = JSON.parse(raw) as Pick<ChatState, 'conversations'>;
+          state = { ...state, conversations: data.conversations || {} };
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    const conv = state.conversations[id];
+    setState({
+      conversationId: id,
+      messages: conv?.messages ?? [],
+      status: conv?.status ?? 'idle',
+    });
+  },
+  clear() {
+    setState((s) => {
+      const id = s.conversationId;
+      if (id) {
+        const rest = { ...s.conversations };
+        delete rest[id];
+        return {
+          conversationId: undefined,
+          messages: [],
+          status: 'idle',
+          conversations: rest,
+        };
+      }
+      return { conversationId: undefined, messages: [], status: 'idle' };
+    });
+  },
+  setStatus(status: ChatStatus) {
+    setState((s) => {
+      const id = s.conversationId;
+      return {
+        status,
+        conversations: id
+          ? { ...s.conversations, [id]: { messages: s.messages, status } }
+          : s.conversations,
+      };
+    });
+  },
+};
+
+// Hydrate conversations map on first import
+if (typeof window !== 'undefined') {
+  try {
+    const raw = localStorage.getItem('chat-store');
+    if (raw) {
+      const data = JSON.parse(raw) as Pick<ChatState, 'conversations'>;
+      state = { ...state, conversations: data.conversations || {} };
+    }
+  } catch {
+    // ignore
+  }
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "chat-store": ["./src/store/chat-store"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add global chat store with conversation history persistence
- hydrate conversation via query string or cookie through a global provider
- expose chat store as a singleton for module federation consumers

## Testing
- `npm run build` *(fails: Failed to fetch font `Inter`: https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap`)*

------
https://chatgpt.com/codex/tasks/task_e_6898fdcd5de08333b6ce206be8433da7