### PR TITLE
feat: add persistent chat store shared across MFEs

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -10,4 +10,8 @@ declare module 'Chatbot/GabsIAWidget';
 // ───────────────────────────────────────────────
 declare module 'Dashboard/Dashboard';
 declare module 'Dashboard/App';
-declare module 'chat-store';
+declare module 'chat-store' {
+  export * from './src/store/chat-store';
+  const useChatStore: typeof import('./src/store/chat-store').default;
+  export default useChatStore;
+}

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -10,3 +10,4 @@ declare module 'Chatbot/GabsIAWidget';
 // ───────────────────────────────────────────────
 declare module 'Dashboard/Dashboard';
 declare module 'Dashboard/App';
+declare module 'chat-store';

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 import { NextFederationPlugin } from '@module-federation/nextjs-mf';
 import { PrismaPlugin } from "@prisma/nextjs-monorepo-workaround-plugin";
+import path from 'path';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -19,6 +20,10 @@ const nextConfig = {
     if (isServer) {
       config.plugins.push(new PrismaPlugin());
     }
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      'chat-store': path.resolve(__dirname, './src/store/chat-store.ts'),
+    };
     config.plugins.push(
       new NextFederationPlugin({
         name: 'shell',
@@ -29,13 +34,19 @@ const nextConfig = {
         exposes: {
           './Error': './src/pages/_error.tsx',
           './Providers': './src/providers/providers.tsx',
+          './chat-store': './src/store/chat-store.ts',
         },
         shared: {
           'react-dom': { singleton: true, requiredVersion: false },
           'next-intl': { singleton: true, requiredVersion: false },
+          'chat-store': {
+            singleton: true,
+            eager: true,
+            import: path.resolve(__dirname, './src/store/chat-store.ts'),
+          },
           // '@gabrielmbatista/ui-library-stencil': {
           //   singleton: true,
-          //   eager: true, 
+          //   eager: true,
           //   requiredVersion: false,
           // },
           // 'next-auth': { singleton: true },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "^15.3.3",
     "next-auth": "^4.24.11",
     "next-intl": "^4.1.0",
+    "zustand": "^4.5.2",
     "prisma": "^6.8.2",
     "puppeteer": "^24.15.0",
     "react": "^18.2.0",

--- a/src/providers/ChatStoreProvider.tsx
+++ b/src/providers/ChatStoreProvider.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import useChatStore from 'chat-store';
+
+export function ChatStoreProvider({ children }: { children: ReactNode }) {
+  const hydrate = useChatStore((s) => s.hydrate);
+  const router = useRouter();
+
+  useEffect(() => {
+    let cid: string | undefined = router.query.cid as string | undefined;
+    if (!cid && typeof document !== 'undefined') {
+      const match = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('cid='));
+      if (match) {
+        cid = match.split('=')[1];
+      }
+    }
+    hydrate(cid);
+  }, [router.query.cid, hydrate]);
+
+  return <>{children}</>;
+}
+
+export default ChatStoreProvider;

--- a/src/providers/ChatStoreProvider.tsx
+++ b/src/providers/ChatStoreProvider.tsx
@@ -2,10 +2,10 @@
 
 import { ReactNode, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import useChatStore from 'chat-store';
+import useChatStore, { ChatStoreState } from 'chat-store';
 
 export function ChatStoreProvider({ children }: { children: ReactNode }) {
-  const hydrate = useChatStore((s) => s.hydrate);
+  const hydrate = useChatStore((s: ChatStoreState) => s.hydrate);
   const router = useRouter();
 
   useEffect(() => {

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -5,12 +5,15 @@ import { I18nProvider } from './I18nProvider';
 import { SessionProvider } from 'next-auth/react';
 import { Session } from 'next-auth';
 import { ResolutionProvider } from './ResolutionProvider';
+import { ChatStoreProvider } from './ChatStoreProvider';
 
 export function Providers({ children, session }: { children: ReactNode; session: Session | null }) {
   return (
     <I18nProvider>
       <ResolutionProvider>
-        <SessionProvider session={session}>{children}</SessionProvider>
+        <SessionProvider session={session}>
+          <ChatStoreProvider>{children}</ChatStoreProvider>
+        </SessionProvider>
       </ResolutionProvider>
     </I18nProvider>
   );

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -16,7 +16,7 @@ interface ConversationsMap {
   [id: string]: ChatMessage[];
 }
 
-interface ChatStoreState {
+export interface ChatStoreState {
   conversationId: string | null;
   messages: ChatMessage[];
   status: ChatStatus;

--- a/src/store/chat-store.ts
+++ b/src/store/chat-store.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export type ChatMessage = {
+  id: string;
+  role: string;
+  text: string;
+  ts: number;
+};
+
+export type ChatStatus = 'idle' | 'sending' | 'error';
+
+interface ConversationsMap {
+  [id: string]: ChatMessage[];
+}
+
+interface ChatStoreState {
+  conversationId: string | null;
+  messages: ChatMessage[];
+  status: ChatStatus;
+  start: (id?: string) => void;
+  append: (msg: ChatMessage | ChatMessage[]) => void;
+  hydrate: (id?: string) => void;
+  clear: (id?: string) => void;
+  _conversations: ConversationsMap; // persisted map
+}
+
+function setCidCookie(cid: string | null) {
+  if (typeof document === 'undefined') return;
+  if (cid) {
+    document.cookie = `cid=${cid}; path=/`;
+  } else {
+    document.cookie = 'cid=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  }
+}
+
+export const useChatStore = create<ChatStoreState>()(
+  persist(
+    (set, get) => ({
+      conversationId: null,
+      messages: [],
+      status: 'idle',
+      _conversations: {},
+      start: (id?: string) => {
+        const cid = id ?? crypto.randomUUID();
+        setCidCookie(cid);
+        const stored = get()._conversations[cid] ?? [];
+        set({ conversationId: cid, messages: stored, status: 'idle' });
+      },
+      append: (msg: ChatMessage | ChatMessage[]) => {
+        const { conversationId, messages, _conversations } = get();
+        if (!conversationId) return;
+        const newMsgs = Array.isArray(msg) ? [...messages, ...msg] : [...messages, msg];
+        set({
+          messages: newMsgs,
+          _conversations: { ..._conversations, [conversationId]: newMsgs },
+        });
+      },
+      hydrate: (id?: string) => {
+        const cid = id ?? get().conversationId;
+        if (!cid) return;
+        const msgs = get()._conversations[cid] ?? [];
+        setCidCookie(cid);
+        set({ conversationId: cid, messages: msgs, status: 'idle' });
+      },
+      clear: (id?: string) => {
+        const cid = id ?? get().conversationId;
+        if (!cid) return;
+        const conv = { ...get()._conversations };
+        delete conv[cid];
+        setCidCookie(null);
+        set({ conversationId: null, messages: [], status: 'idle', _conversations: conv });
+      },
+    }),
+    {
+      name: 'chat-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        conversationId: state.conversationId,
+        messages: state.messages,
+        status: state.status,
+        _conversations: state._conversations,
+      }),
+    }
+  )
+);
+
+export default useChatStore;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "chat-store": ["./src/store/chat-store"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add Zustand-based chat store with localStorage persistence and cookie support
- expose chat store and hydrate provider globally and via module federation
- configure path alias and add zustand dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68990654f8f48333b71626871c52aaf4